### PR TITLE
Update plot_trace.R for tidyr 1.0.0

### DIFF
--- a/script/plot_trace.R
+++ b/script/plot_trace.R
@@ -53,6 +53,7 @@ cpu.col <- names(trace.df)[1]
 trace.df[, (event.cols) := lapply(.SD, function(x) strsplit(gsub("\\s+", " ", x), " ")) ,.SDcols = event.cols]
 trace.df <- melt(trace.df, id.vars=cpu.col)
 trace.df <- unnest(trace.df, value)
+trace.df <- as.data.table(trace.df)
 
 trace.df[, variable := as.character(variable)]
 
@@ -61,7 +62,8 @@ trace.df[, c("variable", "field") := colsplit(trace.df$variable, "_", c("event",
 cols <- c("value", "field")
 trace.df[, (cols) := lapply(.SD, function(x) strsplit(x, "\\|")) ,.SDcols = cols]
 trace.df[, id := 1:nrow(.SD)]
-trace.df <- unnest(trace.df, value, field)
+trace.df <- unnest(trace.df, cols)
+trace.df <- as.data.table(trace.df)
 
 trace.df[, CPU := as.integer(CPU)]
 


### PR DESCRIPTION
`tidyr` 1.0.0 introduces a new interface for `unnest`. Also, `tidyr` functions like `unnest` don't always return a `data.table` when operating on one. This should fix #8. See [this post](https://stackoverflow.com/questions/58463508/r-error-in-variable-as-charactervariable/58486004?noredirect=1#comment103308760_58486004) on stack overflow of a user experiencing errors with `plot_trace.R` due to a different `tidyr` version.